### PR TITLE
🐛 Always display the badge options

### DIFF
--- a/src/components/configuration/config.tsx
+++ b/src/components/configuration/config.tsx
@@ -176,38 +176,30 @@ const Config = ({ repository }: ConfigProp) => {
                     handleChange={handleChange}
                   />
                 )}
-                {repository.stargazerCount > 0 && (
-                  <CheckBoxWrapper
-                    title="Stars"
-                    keyName="stargazers"
-                    checked={config.stargazers?.state}
-                    handleChange={handleChange}
-                  />
-                )}
-                {repository.forkCount > 0 && (
-                  <CheckBoxWrapper
-                    title="Forks"
-                    keyName="forks"
-                    checked={config.forks?.state}
-                    handleChange={handleChange}
-                  />
-                )}
-                {repository.issues.totalCount > 0 && (
-                  <CheckBoxWrapper
-                    title="Issues"
-                    keyName="issues"
-                    checked={config.issues?.state}
-                    handleChange={handleChange}
-                  />
-                )}
-                {repository.pullRequests.totalCount > 0 && (
-                  <CheckBoxWrapper
-                    title="Pull Requests"
-                    keyName="pulls"
-                    checked={config.pulls?.state}
-                    handleChange={handleChange}
-                  />
-                )}
+                <CheckBoxWrapper
+                  title="Stars"
+                  keyName="stargazers"
+                  checked={config.stargazers?.state}
+                  handleChange={handleChange}
+                />
+                <CheckBoxWrapper
+                  title="Forks"
+                  keyName="forks"
+                  checked={config.forks?.state}
+                  handleChange={handleChange}
+                />
+                <CheckBoxWrapper
+                  title="Issues"
+                  keyName="issues"
+                  checked={config.issues?.state}
+                  handleChange={handleChange}
+                />
+                <CheckBoxWrapper
+                  title="Pull Requests"
+                  keyName="pulls"
+                  checked={config.pulls?.state}
+                  handleChange={handleChange}
+                />
               </Row>
             </Space>
           </Form>


### PR DESCRIPTION
Since we provide a social card as a service, the numbers will grow over time even though they maybe 0 at first. (stars, pulls, issues, forks).

Also, without the option, user will not be able to turn off stars if their stars is 0. e.g. https://github-socialify.netlify.app/wei/send

Fixes #14