### PR TITLE
🐛 Fix firefox image download

### DIFF
--- a/src/components/preview/__snapshots__/card.test.tsx.snap
+++ b/src/components/preview/__snapshots__/card.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`Card #1 renders 1`] = `
 <svg
   className="card-svg-wrapper"
+  height="320px"
   viewBox="0 0 640 320"
+  width="640px"
   xmlns="http://www.w3.org/2000/svg"
 >
   <foreignObject
@@ -59,7 +61,9 @@ exports[`Card #1 renders 1`] = `
 exports[`Card #2 renders 1`] = `
 <svg
   className="card-svg-wrapper"
+  height="320px"
   viewBox="0 0 640 320"
+  width="640px"
   xmlns="http://www.w3.org/2000/svg"
 >
   <foreignObject

--- a/src/components/preview/card.tsx
+++ b/src/components/preview/card.tsx
@@ -36,6 +36,8 @@ const Card: React.FC<Configuration> = config => {
   return (
     <svg
       className="card-svg-wrapper"
+      width="640px"
+      height="320px"
       viewBox="0 0 640 320"
       xmlns="http://www.w3.org/2000/svg">
       <foreignObject x="0" y="0" width="640" height="320">


### PR DESCRIPTION
Firefox requires svgs to have width and height preset in order to by rendered onto canvas using `drawImage`.