### PR TITLE
⚡️ Update default cache time

### DIFF
--- a/pages/api/svg.ts
+++ b/pages/api/svg.ts
@@ -10,7 +10,7 @@ const svgEndpoint = async (req: NextApiRequest, res: NextApiResponse) => {
     const svg = await renderCard(query)
     res.setHeader(
       'Cache-Control',
-      `max-age=${'cache' in req.query ? req.query.cache : 14400}, public`
+      `max-age=${'cache' in req.query ? req.query.cache : 3600}, public`
     )
     res.setHeader('Content-Type', 'image/svg+xml')
     res.send(svg)


### PR DESCRIPTION
Relates to #71 #72 #74 

Currently, we still have GraphQL request caching which is 10 minutes. So the badge numbers will not change within 10 minutes of a request.