### PR TITLE
📝 Add GitHub access token instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-# Add your GitHub Token here
 GITHUB_TOKEN=
 PROJECT_URL=http://localhost:3000
 GTM_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Add your GitHub Token here
 GITHUB_TOKEN=
 PROJECT_URL=http://localhost:3000
 GTM_ID=

--- a/README.md
+++ b/README.md
@@ -54,19 +54,20 @@ You can use cli tool [mheap/github-social-image](https://github.com/mheap/github
 
 ## Development
 
-- Create a GitHub API access token by heading to `Settings > Developer settings > Personal access tokens` and add that to the `.env.example` file.
+- Create a GitHub token from `Settings > Developer settings > Personal access tokens`, you'll need it in when setting up environemnt variables.
 - Run the following commands to set up the Development server:
-```shell
-# Clone
-git clone https://github.com/wei/socialify.git && cd socialify
 
-# Set environment variables in .env
-cp .env.example .env
+  ```shell
+  # Clone
+  git clone https://github.com/wei/socialify.git && cd $_
 
-yarn install
-yarn build
-yarn dev
-```
+  # Set environment variables in .env
+  cp .env.example .env
+
+  yarn install
+  yarn build
+  yarn dev
+  ```
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ You can use cli tool [mheap/github-social-image](https://github.com/mheap/github
 
 ## Development
 
+- Create a GitHub API access token by heading to `Settings > Developer settings > Personal access tokens` and add that to the `.env.example` file.
+- Run the following commands to set up the Development server:
 ```shell
 # Clone
 git clone https://github.com/wei/socialify.git && cd socialify


### PR DESCRIPTION
The Development section inside the README does not contain the step to obtain and add the `GITHUB_TOKEN` to the env file.
For beginners, this might not be obvious and adding that to the README would help them set things up easily.