### PR TITLE
Add svelte icon

### DIFF
--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -29,6 +29,7 @@ const getDevIconClassName = (language: string, theme: Theme): string => {
     Ruby: 'ruby-plain',
     Rust: 'rust-plain',
     Scala: 'scala-plain',
+    Svelte: 'svelte-plain',
     Swift: 'swift-plain',
     TypeScript: 'typescript-plain',
     GitHub: 'github-original',


### PR DESCRIPTION
This PR fixes #131 
- Added `devicon-svelte-plain` by adding `svelte-plain` in `LANGUAGE_ICON_MAPPING` in `common/helpers.ts`.

> Note: I am not sure, if this works already, since I wasn't able to get the app running on my local environment. But from what I read in the code, this should be good enough to go!