### PR TITLE
🐛 Change `word-break` style of description

### DIFF
--- a/.changeset/short-trains-push.md
+++ b/.changeset/short-trains-push.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Change `word-break` style of description

--- a/.changeset/short-trains-push.md
+++ b/.changeset/short-trains-push.md
@@ -1,5 +1,5 @@
 ---
-"socialify": patch
+"socialify": minor
 ---
 
 Change `word-break` style of description

--- a/src/components/preview/__snapshots__/card.test.tsx.snap
+++ b/src/components/preview/__snapshots__/card.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Card #2 renders 1`] = `
   </p>
   <p
     class="card-description-wrapper"
-    style="display: flex; justify-content: center; width: 100%; margin-top: 10px; margin-bottom: 0px; font-size: 17px; line-height: 1.4; max-height: 3em; overflow: hidden; word-break: break-all; white-space: pre-wrap;"
+    style="display: flex; justify-content: center; width: 100%; margin-top: 10px; margin-bottom: 0px; font-size: 17px; line-height: 1.4; max-height: 3em; overflow: hidden; word-break: break-word; white-space: pre-wrap;"
   >
     TEST DESCRIPTION
   </p>

--- a/src/components/preview/card.tsx
+++ b/src/components/preview/card.tsx
@@ -143,7 +143,7 @@ export const Card = (config: Configuration) => {
             lineHeight: 1.4,
             maxHeight: '3em',
             overflow: 'hidden',
-            wordBreak: 'break-all',
+            wordBreak: 'break-word',
             whiteSpace: 'pre-wrap'
           }}>
           {config.description.value}


### PR DESCRIPTION
Use `break-word` instead of `break-all` to avoid breaking in the middle of the words in description.

Before:
![barcode-detector before](https://github.com/wei/socialify/assets/10386119/a556576f-ad77-4fe0-aea7-5f01b97072ec)

After:
![barcode-detector after](https://github.com/wei/socialify/assets/10386119/125d5061-fd03-4cea-8c9b-f6150f2bb474)
