### PR TITLE
📈 Adopted nextjs's maintained google tag manager

### DIFF
--- a/.changeset/proud-years-sip.md
+++ b/.changeset/proud-years-sip.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Migrated from hard-coded solution to using @next/third-parties/google GoogleTagManager component.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node": "22"
   },
   "dependencies": {
+    "@next/third-parties": "^15.1.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "badgen": "^3.2.3",
     "clsx": "^2.1.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
+import { GoogleTagManager } from '@next/third-parties/google'
 import App from 'next/app'
 import { Inter } from 'next/font/google'
 import Head from 'next/head'
-import Script from 'next/script'
 import { Toaster } from 'react-hot-toast'
 
 import '../styles/global.css'
@@ -12,37 +12,6 @@ import HeaderElement from '../src/components/header/header'
 const inter = Inter({
   subsets: ['latin'],
 })
-
-const GoogleTagManager = () => {
-  if (process.env.GTM_ID) {
-    return (
-      <>
-        <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GTM_ID}`}
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){window.dataLayer.push(arguments);}
-            gtag('js', new Date());
-
-            gtag('config', '${process.env.GTM_ID}');
-          `}
-        </Script>
-      </>
-    )
-  }
-
-  return (
-    <Script id="google-analytics">
-      {`
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-      `}
-    </Script>
-  )
-}
 
 export default class MyApp extends App {
   public render() {
@@ -70,7 +39,6 @@ export default class MyApp extends App {
           <link rel="apple-touch-icon" href="/assets/logo192.png" />
           <link rel="manifest" href="/manifest.json" />
           <title>GitHub Socialify</title>
-          {GoogleTagManager()}
         </Head>
         <main
           className={`${inter.className} flex flex-col min-h-screen socialify-bg`}
@@ -82,6 +50,8 @@ export default class MyApp extends App {
           <FooterElement />
           <Toaster />
         </main>
+        {/* Google Tag Manager, env only relevant/accessbile to owner, use '' for dev. */}
+        <GoogleTagManager gtmId={process.env.GTM_ID || ''} />
       </>
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -864,6 +864,13 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.18.tgz#91d56970f0e484c7e4f8a9f11635d82552e0fce1"
   integrity sha512-dtRGMhiU9TN5nyhwzce+7c/4CCeykYS+ipY/4mIrGzJ71+7zNo55ZxCB7cAVuNqdwtYniFNR2c9OFQ6UdFIMcg==
 
+"@next/third-parties@^15.1.0":
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/@next/third-parties/-/third-parties-15.1.0.tgz#ab898927a006fe41ef90888220b51e22e11e110c"
+  integrity sha512-eiv8vTo5HJOE/LabnIjRNVpN0hvjXfqPrE7D/XecmWvHBs9KrIISxlb1NZizDMcvjGtnHkdupWsquM9ur25rYw==
+  dependencies:
+    third-party-capital "1.0.20"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3829,6 +3836,11 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+third-party-capital@1.0.20:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/third-party-capital/-/third-party-capital-1.0.20.tgz#e218a929a35bf4d2245da9addb8ab978d2f41685"
+  integrity sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==
 
 tiny-inflate@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
# Production Dependency Upgrade

Migrated away from hard-coded Google Tag Manager to using the officially recommended @next/third-parties/google package. Added as prod deps.

## Before

Ref https://github.com/wei/socialify/blob/a42fac650d83ae756f36eb7bb3388543f8b7cae1/pages/_app.tsx

```Typescript
const GoogleTagManager = () => {
  if (process.env.GTM_ID) {
    return (
      <>
        <Script
          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GTM_ID}`}
          strategy="afterInteractive"
        />
        <Script id="google-analytics">
          {`
            window.dataLayer = window.dataLayer || [];
            function gtag(){window.dataLayer.push(arguments);}
            gtag('js', new Date());

            gtag('config', '${process.env.GTM_ID}');
          `}
        </Script>
      </>
    )
  }

  return (
    <Script id="google-analytics">
      {`
        window.dataLayer = window.dataLayer || [];
        function gtag(){dataLayer.push(arguments);}
      `}
    </Script>
  )
}
```

## After

Ref https://github.com/KemingHe/contrib-socialify/blob/1f427f881293207a670455f12c944d59897b86d4/pages/_app.tsx

```Typescript
{/* Google Tag Manager, env only relevant/accessibile to owner, use '' for dev. */}
<GoogleTagManager gtmId={process.env.GTM_ID || ''} />
```