### PR TITLE
💚 Require GITHUB_TOKEN in CI

### DIFF
--- a/.changeset/heavy-vans-tickle.md
+++ b/.changeset/heavy-vans-tickle.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Limited GITHUB_TOKEN process.env check to CI only, as 'next start` in Playwright auto-loads .env for local devs.

--- a/next.config.js
+++ b/next.config.js
@@ -28,10 +28,6 @@ const nextConfig = {
       },
     ]
   },
-  // Disable NextJS dev server icon for Playwright screenshot consistency.
-  devIndicators: {
-    appIsrStatus: false,
-  },
 }
 
 module.exports = nextConfig

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -50,7 +50,7 @@ export default class MyApp extends App {
           <FooterElement />
           <Toaster />
         </main>
-        {/* Google Tag Manager, env only relevant/accessbile to owner, use '' for dev. */}
+        {/* Google Tag Manager, env only relevant/accessible to owner, use '' for dev. */}
         <GoogleTagManager gtmId={process.env.GTM_ID || ''} />
       </>
     )

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from '@playwright/test'
 
-if (!process.env.GITHUB_TOKEN) {
+// Insta-fail the test run in CI if GITHUB_TOKEN is not set.
+// This is because `next start` auto-loads dev-side .env files,
+// which are not present in GitHub Action CI run.
+if (process.env.CI && !process.env.GITHUB_TOKEN) {
   console.error('Please set GITHUB_TOKEN before running the tests')
   process.exit(1)
 }


### PR DESCRIPTION
Very simple and effective fix that stays within the CI boundaries, not affecting application:

Ref https://github.com/KemingHe/contrib-socialify/blob/d6e32fa50be0ef1702c2889d0a2a5ff32cb09671/playwright.config.ts

```Typescript
// Insta-fail the test run in CI if GITHUB_TOKEN is not set.
// This is because `next start` auto-loads dev-side .env files,
// which are not present in GitHub Action CI run.
if (process.env.CI && !process.env.GITHUB_TOKEN) {
  console.error('Please set GITHUB_TOKEN before running the tests')
  process.exit(1)
}
```

Also fixed typo in comments introduced when resolving #423 .

Solution to fix #422 . Edit: more context.