### PR TITLE
🐛 Corrected `jest` update snapshot(s) cli flag back to `-u`

### DIFF
--- a/.changeset/happy-chairs-serve.md
+++ b/.changeset/happy-chairs-serve.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Corrected jest update snapshot(s) flag back to -u.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "next build",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch",
-    "test:unit:update-snapshots": "jest --update",
+    "test:unit:update-snapshots": "jest -u",
     "test:e2e": "playwright test",
     "test:e2e:update-snapshots": "playwright test --update-snapshots",
     "test": "pnpm test:unit && pnpm test:e2e",


### PR DESCRIPTION
I made a mistake in previous commit when polishing the `pnpm` scripts. Now `pnpm unit:test:update-snapshots` will trigger the correct `jest -u` cli command to run unit tests and update snapshots. Apologies @wei .