### PR TITLE
🐛 Fix: langing page footer cached to display incorrect version, two solutions

### DIFF
--- a/.changeset/tall-students-accept.md
+++ b/.changeset/tall-students-accept.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Fixed incorrect footer cache behavior, allowing version update to correctly show.

--- a/.playwright/imageAPIEndpoints.spec.ts
+++ b/.playwright/imageAPIEndpoints.spec.ts
@@ -1,14 +1,13 @@
 import { type Page, expect, test } from '@playwright/test'
 
 const customTimeout = { timeout: 30000 }
-
 const defaultImageURL: string =
   '/wei/socialify/image?description=1&font=Raleway&language=1&name=1&owner=1&pattern=Diagonal%20Stripes&theme=Dark'
 const svgImageURL: string =
   '/wei/socialify/svg?description=1&font=Raleway&language=1&name=1&owner=1&pattern=Diagonal%20Stripes&theme=Dark'
 const pngImageURL: string =
   '/wei/socialify/png?description=1&font=Raleway&language=1&name=1&owner=1&pattern=Diagonal%20Stripes&theme=Dark'
-// Backward compatibility route.
+// Backward compatibility route, see ./next.config.js rewrite rules.
 const jpgImageURL: string =
   '/wei/socialify/jpg?description=1&font=Raleway&language=1&name=1&owner=1&pattern=Diagonal%20Stripes&theme=Dark'
 
@@ -17,8 +16,6 @@ test.describe('Socialify image api', () => {
     page,
   }: { page: Page }): Promise<void> => {
     await page.goto(defaultImageURL, customTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customTimeout)
 
     const image = await page.screenshot()
@@ -29,8 +26,6 @@ test.describe('Socialify image api', () => {
     page,
   }: { page: Page }): Promise<void> => {
     await page.goto(svgImageURL, customTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customTimeout)
 
     const image = await page.screenshot()
@@ -41,8 +36,6 @@ test.describe('Socialify image api', () => {
     page,
   }: { page: Page }): Promise<void> => {
     await page.goto(pngImageURL, customTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customTimeout)
 
     const image = await page.screenshot()
@@ -53,8 +46,6 @@ test.describe('Socialify image api', () => {
     page,
   }: { page: Page }): Promise<void> => {
     await page.goto(jpgImageURL, customTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customTimeout)
 
     const image = await page.screenshot()

--- a/.playwright/mainUIConsistency.spec.ts
+++ b/.playwright/mainUIConsistency.spec.ts
@@ -6,15 +6,13 @@ import {
 } from '@playwright/test'
 
 const customPageLoadTimeout = { timeout: 30000 }
-
+const additionalPageLoadTimeout = 1000
+const componentUpdateTimeout = 1000
 // As a known CI issue, allow max 1% deviation in pixel diff.
 const customDiffPixelRatio = { maxDiffPixelRatio: 0.01 }
-
 const customScreenshotOptions: PageScreenshotOptions = {
   style: '.no-screenshot{display:none !important}',
 }
-
-// Testing constants.
 const repoPreviewURL: string =
   '/wei/socialify?language=1&owner=1&name=1&stargazers=1&theme=Light'
 
@@ -23,10 +21,8 @@ test.describe('Socialify UI:', () => {
     page,
   }: { page: Page }): Promise<void> => {
     await page.goto('/', customPageLoadTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customPageLoadTimeout)
-    await page.waitForTimeout(5000)
+    await page.waitForTimeout(additionalPageLoadTimeout)
 
     const image = await page.screenshot(customScreenshotOptions)
     expect(image).toMatchSnapshot(customDiffPixelRatio)
@@ -36,9 +32,8 @@ test.describe('Socialify UI:', () => {
     page,
   }: { page: Page }): Promise<void> => {
     await page.goto('/404', customPageLoadTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customPageLoadTimeout)
+    await page.waitForTimeout(additionalPageLoadTimeout)
 
     const image = await page.screenshot(customScreenshotOptions)
     expect(image).toMatchSnapshot(customDiffPixelRatio)
@@ -47,26 +42,23 @@ test.describe('Socialify UI:', () => {
   test('is consistent for preview config page', async ({
     page,
   }: { page: Page }): Promise<void> => {
-    await page.goto(repoPreviewURL, customPageLoadTimeout)
-
     // Wait for the page to load/hydrate completely.
+    await page.goto(repoPreviewURL, customPageLoadTimeout)
     await page.waitForLoadState('networkidle', customPageLoadTimeout)
+    await page.waitForTimeout(additionalPageLoadTimeout)
 
     await page.click('input[name="stargazers"]')
+    await page.waitForTimeout(componentUpdateTimeout)
     await page.click('input[name="description"]')
-
-    // Wait for the component transition/animation to finish completely.
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(componentUpdateTimeout)
 
     const image = await page.screenshot(customScreenshotOptions)
     expect(image).toMatchSnapshot(customDiffPixelRatio)
 
-    // Also check the toaster UI consistency.
+    // Also check the toaster UI consistency, wait for transition to complete.
     await page.click('button:has-text("URL")')
     await page.waitForSelector('[role="alert"]', customPageLoadTimeout)
-
-    // Wait for the component transition/animation to finish completely.
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(componentUpdateTimeout)
 
     const toastImage = await page.screenshot(customScreenshotOptions)
     expect(toastImage).toMatchSnapshot(customDiffPixelRatio)
@@ -76,8 +68,6 @@ test.describe('Socialify UI:', () => {
     page,
   }: { page: Page }): Promise<void> => {
     await page.goto(repoPreviewURL, customPageLoadTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customPageLoadTimeout)
 
     await page
@@ -94,10 +84,9 @@ test.describe('Socialify UI:', () => {
     )
 
     await page.click('input[name="stargazers"]')
+    await page.waitForTimeout(componentUpdateTimeout)
     await page.click('input[name="description"]')
-
-    // Wait for the component transition/animation to finish completely.
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(componentUpdateTimeout)
 
     const image = await page.screenshot(customScreenshotOptions)
     expect(image).toMatchSnapshot(customDiffPixelRatio)

--- a/.playwright/simpleUserStory.spec.ts
+++ b/.playwright/simpleUserStory.spec.ts
@@ -2,8 +2,6 @@ import { type Page, expect, test } from '@playwright/test'
 
 const customTimeout = { timeout: 30000 }
 const componentUpdateTimeout = 1000
-
-// Testing constants.
 const repo: string = 'wei/socialify'
 const expectedConfigURL: string =
   '/wei/socialify?language=1&owner=1&name=1&stargazers=1&theme=Light'
@@ -18,8 +16,6 @@ async function getClipboardText(page: Page): Promise<string> {
 
 test.beforeEach(async ({ page }: { page: Page }): Promise<void> => {
   await page.goto('/', customTimeout)
-
-  // Wait for the page to load/hydrate completely.
   await page.waitForLoadState('networkidle', customTimeout)
 })
 
@@ -32,10 +28,8 @@ test.describe('A simple user story:', () => {
     await page.waitForTimeout(componentUpdateTimeout)
     await page.click('button[type="submit"]')
 
-    // Wait for navigation to the preview config page.
+    // Wait for complete navigation to the preview config page.
     await page.waitForSelector('button:has-text("URL")', customTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customTimeout)
     await expect(page).toHaveURL(expectedConfigURL)
 
@@ -43,12 +37,14 @@ test.describe('A simple user story:', () => {
     await page.waitForTimeout(componentUpdateTimeout)
     await page.click('input[name="description"]')
     await page.waitForTimeout(componentUpdateTimeout)
+
     // Select the "Source Code Pro" option for max diff from default.
     await page.selectOption('select[name="font"]', { label: 'Source Code Pro' })
     await page.waitForTimeout(componentUpdateTimeout)
 
     // Obtain the consistent preview image URL.
     await page.click('button:has-text("URL")')
+    await page.waitForTimeout(componentUpdateTimeout)
 
     // Compare the clipboard content to the expected image URL.
     // (Only check the end of the URL due to dynamic localhost port allocation.)
@@ -57,8 +53,6 @@ test.describe('A simple user story:', () => {
 
     // Visit the image URL and snapshot the image.
     await page.goto(url, customTimeout)
-
-    // Wait for the page to load/hydrate completely.
     await page.waitForLoadState('networkidle', customTimeout)
 
     const image = await page.screenshot()

--- a/next.config.js
+++ b/next.config.js
@@ -28,9 +28,24 @@ const nextConfig = {
       {
         source: '/:path*',
         headers: [
+          // Custom version header.
           {
             key: 'x-socialify-version',
             value: version,
+          },
+          // Cache control headers.
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, must-revalidate',
+          },
+          // Pragma and Expires headers for legacy HTTP/1.0 support.
+          {
+            key: 'Pragma',
+            value: 'no-cache',
+          },
+          {
+            key: 'Expires',
+            value: '0',
           },
         ],
       },


### PR DESCRIPTION
## Problem

Landing page and other static assets are cached for 1 year by NextJS 15 default setting, read more here: [`https://nextjs.org/docs/app/api-reference/config/next-config-js/headers#cache-control`](https://nextjs.org/docs/app/api-reference/config/next-config-js/headers#cache-control)

Current `production` landing page (static) footer displays the outdated version of `v12.7.0`, 

<img width="397" alt="Screenshot 2024-12-20 at 12 02 43 PM" src="https://github.com/user-attachments/assets/c86b2970-a8f4-40f0-bac3-5ecc227bcb7c" />

_while the **dynamic** repo preview config page doesn't have this issue, and display the correct version of `v2.18.1`_.

<img width="397" alt="Screenshot 2024-12-20 at 12 02 31 PM" src="https://github.com/user-attachments/assets/177f96a7-95c8-410c-b486-5b92608a4c03" />

## Solution Candidates

To resolve #462 

### 1. Request Header-based

Allow static pre-rendering of landing page, but force revalidate in request headers for all routes (can change to just landing page as well), set in `next.config.js`:

https://github.com/KemingHe/contrib-socialify/blob/c40619c964394501781de6d8458c527cf1fe8654/next.config.js#L26-L54

### 2. Build-based

Put `export const dynamic = 'force-dynamic` in `app/layout.tsx` to force dynamic for all routes, disabling static pre-rendering (can change to just setting it for landing page as well). 

<hr />

I'm open to other proposals and heads-ups, still learning here. ☀️ Edit: additional context.
