### PR TITLE
🐛 Fix unexpected page caching

### DIFF
--- a/.changeset/gentle-moles-hug.md
+++ b/.changeset/gentle-moles-hug.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Fix unexpected page caching

--- a/app/[_owner]/[_name]/page.tsx
+++ b/app/[_owner]/[_name]/page.tsx
@@ -4,6 +4,8 @@ import { JSX } from 'react'
 
 import MainRenderer from '@/src/components/mainRenderer'
 
+export const runtime = 'edge'
+
 export default function PreviewConfigPage(): JSX.Element {
   return <MainRenderer />
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,8 @@ import { JSX } from 'react'
 
 import Repo from '@/src/components/repo/repo'
 
+export const runtime = 'edge'
+
 export default function HomePage(): JSX.Element {
   return <Repo />
 }


### PR DESCRIPTION
Use edge runtime on all pages to prevent ISR which was setting unexpected cache-control headers.

Closes #462
Closes #469