### PR TITLE
🔒️ Pinned all 3rd party actions to latest release commit hashes

### DIFF
--- a/.changeset/lovely-drinks-notice.md
+++ b/.changeset/lovely-drinks-notice.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Pinned all 3rd party actions to latest commit hash to prevent against supply chain attacks, per recommended by GitHub CodeQL.

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -40,7 +40,8 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.get_version.outputs.version != ''
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        # Pinned to commit hash of release v2.2.0 on 12/10/24.
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
           name: Release v${{ steps.get_version.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+        # Pinned to commit hash of release v4.0.0 on 05/07/24.
         
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        # Pinned to commit hash of release v3.3.0 on 07/22/24.
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,13 +35,15 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
+        # Pinned to commit hash of release v5.6.1 on 11/19/24.
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+        # Pinned to commit hash of release v6.10.0 on 11/26/24.
         with:
           context: .
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+        # Pinned to commit hash of release v4.0.0 on 05/07/24.
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+        # Pinned to commit hash of release v4.0.0 on 05/07/24.
         
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,7 +29,8 @@ jobs:
         run: pnpm install
 
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308
+        # Pinned to commit hash of release v1.4.9 on 10/14/24.
         with:
           commit: 🔖 Bump version
           title: 🔖 Bump version


### PR DESCRIPTION
Using broad versions (i.e. v4) rather than specific commit hashes makes the workflow vulnerable to supply chain attacks. This is considered a **medium** level security risk by GitHub CodeQL and is reported and explain in #480.

This PR fixes #480 .  