### PR TITLE
👷 Enable Docker BuildKit caching

### DIFF
--- a/.changeset/docker-build-cache.md
+++ b/.changeset/docker-build-cache.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Add Docker build caching in GitHub Actions to speed up multi-stage builds.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         id: build-push
         uses: docker/build-push-action@v6
@@ -46,6 +49,8 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
## Summary
- enable Docker Buildx cache via GitHub Actions
- revert Dockerfile cache mounts
- document the workflow improvement in a changeset

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_684487ed13888323959b7285586b85b0