### PR TITLE
Enable multi-arch Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -49,6 +52,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/s390x
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- update Docker GitHub workflow to build images for amd64, arm64, arm/v7 and s390x

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fetch failed)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_6844ca26896c83238682b0e9078df4ac