### PR TITLE
fix: update jest config for Next 15

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,15 @@
+import { readFileSync } from 'node:fs'
 import type { Config } from '@jest/types'
-import nextJest from 'next/jest'
+// Next.js 15 requires explicit file extension for the Jest helper
+// See: https://github.com/vercel/next.js/pull/58249
+import nextJest from 'next/jest.js'
 import { pathsToModuleNameMapper } from 'ts-jest'
 
-import { compilerOptions } from './tsconfig.json'
+// tsconfig.json is imported for path aliases; we read it via fs to
+// avoid JSON import assertions issues in newer Node versions.
+const { compilerOptions } = JSON.parse(
+  readFileSync(new URL('./tsconfig.json', import.meta.url), 'utf-8')
+)
 
 const createJestConfig = nextJest({
   dir: './',


### PR DESCRIPTION
## Summary
- fix jest config import for Next.js 15
- load tsconfig via `fs` to avoid JSON import assertion issues in Node 22

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68989db85ed0832382704f573424f952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration handling to improve compatibility with newer Next.js and Node.js versions. No changes to app features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->