### PR TITLE
💚 Sync biome schema with CLI version

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary
- update `biome.json` schema to 2.1.3 to match installed CLI and remove lint warning

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch failed for fonts)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_b_6899005c632c8323853c302f32d3c175