### PR TITLE
🤖 fix #849: 🐛 Stat toggles like stargazers=1 no longer turn stats on

### DIFF
--- a/.changeset/fix-stat-toggles.md
+++ b/.changeset/fix-stat-toggles.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Fix stat toggles so "1" is treated as enabled in mergeConfig

--- a/common/configHelper.ts
+++ b/common/configHelper.ts
@@ -111,7 +111,7 @@ const mergeConfig = (
     for (const key in query) {
       if (key in OptionalConfigsKeys) {
         Object.assign(config[key as Key] ?? {}, {
-          state: query[key as Key] === 'true',
+          state: query[key as Key] === '1' || query[key as Key] === 'true',
         })
         if (config[key as Key]?.editable) {
           const editableValue =


### PR DESCRIPTION
Closes #849

Fixed on `factory-demo`.

- Updated `common/configHelper.ts` so `mergeConfig` treats both `"1"` and `"true"` as enabled for every `OptionalConfigsKeys` stat, matching the README/URL convention.
- Added `.changeset/fix-stat-toggles.md`.
- `common/configHelper.test.ts` now passes.

Diff:
```diff
-          state: query[key as Key] === 'true',
+          state: query[key as Key] === '1' || query[key as Key] === 'true',
```

[0mbiome.json[0m[0m:[0m[0m30[0m[0m:[0m[0m13[0m[0m [0m[0mdeserialize[0m[0m [0m[0m[30m[47m DEPRECATED [0m[0m [0m[0m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m[0m

[0m[0m  [0m[0m[1m[34mℹ[0m[0m [0m[0m[34mThe use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.[0m[0m
[0m[0m  [0m[0m
[0m[0m  [0m[0m [0m[0m  [0m[0m[1m28 │ [0m[0m [0m[0m [0m[0m}[0m[0m,[0m[0m
[0m[0m  [0m[0m [0m[0m  [0m[0m[1m29 │ [0m[0m [0m[0m [0m[0m"[0m[0ma[0m[0ms[0m[0ms[0m[0mi[0m[0ms[0m[0mt[0m[0m"[0m[0m:[0m[0m [0m[0m{[0m[0m [0m[0m"[0m[0ma[0m[0mc[0m[0mt[0m[0mi[0m[0mo[0m[0mn[0m[0ms[0m[0m"[0m[0m:[0m[0m [0m[0m{[0m[0m [0m[0m"[0m[0ms[0m[0mo[0m[0mu[0m[0mr[0m[0mc[0m[0me[0m[0m"[0m[0m:[0m[0m [0m[0m{[0m[0m [0m[0m"[0m[0mo[0m[0mr[0m[0mg[0m[0ma[0m[0mn[0m[0mi[0m[0mz[0m[0me[0m[0mI[0m[0mm[0m[0mp[0m[0mo[0m[0mr[0m[0mt[0m[0ms[0m[0m"[0m[0m:[0m[0m [0m[0m"[0m[0mo[0m[0mn[0m[0m"[0m[0m [0m[0m}[0m[0m [0m[0m}[0m[0m [0m[0m}[0m[0m,[0m[0m
[0m[0m  [0m[0m [0m[0m[1m[31m>[0m[0m [0m[0m[1m30 │ [0m[0m [0m[0m [0m[0m"[0m[0ml[0m[0mi[0m[0mn[0m[0mt[0m[0me[0m[0mr[0m[0m"[0m[0m:[0m[0m [0m[0m{[0m[0m
[0m[0m  [0m[0m [0m[0m [0m[0m [0m[0m[1m   │ [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m[1m[31m^[0m[0m
[0m[0m  [0m[0m [0m[0m[1m[31m>[0m[0m [0m[0m[1m31 │ [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m"[0m[0me[0m[0mn[0m[0ma[0m[0mb[0m[0ml[0m[0me[0m[0md[0m[0m"[0m[0m:[0m[0m [0m[0mt[0m[0mr[0m[0mu[0m[0me[0m[0m,[0m[0m
[0m[0m  [0m[0m [0m[0m [0m[0m [0m[0m[1m    ...
[0m[0m  [0m[0m[1m[31m>[0m[0m [0m[0m[1m119 │ [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m}[0m[0m
[0m[0m  [0m[0m[1m[31m>[0m[0m [0m[0m[1m120 │ [0m[0m [0m[0m [0m[0m}[0m[0m,[0m[0m
[0m[0m  [0m[0m [0m[0m [0m[0m [0m[0m[1m   │ [0m[0m [0m[0m [0m[0m[1m[31m^[0m[0m
[0m[0m  [0m[0m  [0m[0m[1m121 │ [0m[0m [0m[0m [0m[0m"[0m[0mj[0m[0ma[0m[0mv[0m[0ma[0m[0ms[0m[0mc[0m[0mr[0m[0mi[0m[0mp[0m[0mt[0m[0m"[0m[0m:[0m[0m [0m[0m{[0m[0m
[0m[0m  [0m[0m  [0m[0m[1m122 │ [0m[0m [0m[0m [0m[0m [0m[0m [0m[0m"[0m[0mf[0m[0mo[0m[0mr[0m[0mm[0m[0ma[0m[0mt[0m[0mt[0m[0me[0m[0mr[0m[0m"[0m[0m:[0m[0m [0m[0m{[0m[0m
[0m[0m  [0m[0m
[0m[0m  [0m[0m[1m[34mℹ[0m[0m [0m[0m[34mMigrate the configuration with the proper command[0m[0m
[0m[0m  [0m[0m
[0m[0m  [0m[0m[1m$[0m[0m [0m[0mbiome migrate[0m[0m
[0m[0m  [0m[0m
[0m
PASS src/components/configuration/config.test.tsx
PASS src/components/configuration/repositoryInput.test.tsx
PASS src/components/preview/cardThemeWrapper.test.tsx
PASS common/configHelper.test.ts
PASS src/components/header/header.test.tsx
PASS src/components/configuration/inputWrapper.test.tsx
PASS src/components/repo/repo.test.tsx
PASS src/components/configuration/logoInput.test.tsx
PASS src/components/footer/footer.test.tsx
PASS src/components/error/error.test.tsx
PASS src/components/preview/badge.test.tsx

Test Suites: 11 passed, 11 total
Tests:       62 passed, 62 total
Snapshots:   15 passed, 15 total
Time:        1.195 s
Ran all test suites.
[0m[34mChecked 71 files in 21[0m[0m[2m[34mms[0m[0m[34m.[0m[0m[34m No fixes applied.[0m[0m
[0m[0m[34mFound [0m[0m[34m1[0m[0m[34m info.[0m
