### PR TITLE
🤖 fix #851: 🐛 Transparent pattern should use the theme colour as background

### DIFF
--- a/.changeset/transparent-theme-bg.md
+++ b/.changeset/transparent-theme-bg.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Use the theme background color for the Transparent pattern instead of fully transparent

--- a/common/helpers.test.ts
+++ b/common/helpers.test.ts
@@ -1,0 +1,22 @@
+import { getHeroPattern } from '@/common/helpers'
+import { Pattern, Theme } from '@/common/types/configType'
+
+describe('getHeroPattern', () => {
+  test('returns a transparent background for transparent pattern', () => {
+    expect(getHeroPattern(Pattern.transparent, Theme.light)).toStrictEqual({
+      backgroundColor: '#fff',
+    })
+    expect(getHeroPattern(Pattern.transparent, Theme.dark)).toStrictEqual({
+      backgroundColor: '#000',
+    })
+  })
+
+  test('returns a themed solid background for solid pattern', () => {
+    expect(getHeroPattern(Pattern.solid, Theme.light)).toStrictEqual({
+      backgroundColor: '#fff',
+    })
+    expect(getHeroPattern(Pattern.solid, Theme.dark)).toStrictEqual({
+      backgroundColor: '#000',
+    })
+  })
+})

--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -31,12 +31,7 @@ const getHeroPattern = (pattern: Pattern, theme: Theme): CSSProperties => {
     [Pattern.transparent]: null,
   }
   const patternFunction = PATTERN_FUNCTIONS_MAPPING[pattern]
-  const themedBackgroundColor =
-    pattern === Pattern.transparent
-      ? 'transparent'
-      : theme === Theme.dark
-        ? '#000'
-        : '#fff'
+  const themedBackgroundColor = theme === Theme.dark ? '#000' : '#fff'
 
   if (!patternFunction) {
     return {


### PR DESCRIPTION
Closes #851

Done.

**Summary of changes:**

- `common/helpers.ts`: `getHeroPattern` now uses the theme colour (`#000` for dark, `#fff` for light) as the background for `Pattern.transparent`, matching other patterns, instead of returning `'transparent'`.
- `common/helpers.test.ts`: added unit tests covering `Pattern.transparent` and `Pattern.solid` for both light and dark themes.
- `.changeset/transparent-theme-bg.md`: added the required changeset.

biome.json:30:13 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.
  
     28 │   },
     29 │   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   > 30 │   "linter": {
        │             ^
   > 31 │     "enabled": true,
         ...
  > 119 │     }
  > 120 │   },
        │   ^
    121 │   "javascript": {
    122 │     "formatter": {
  
  i Migrate the configuration with the proper command
  
  $ biome migrate
  

PASS src/components/configuration/config.test.tsx
PASS src/components/preview/cardThemeWrapper.test.tsx
PASS src/components/configuration/repositoryInput.test.tsx
PASS src/components/header/header.test.tsx
PASS common/helpers.test.ts
PASS src/components/configuration/inputWrapper.test.tsx
PASS src/components/configuration/logoInput.test.tsx
PASS src/components/repo/repo.test.tsx
PASS src/components/error/error.test.tsx
PASS src/components/footer/footer.test.tsx
PASS src/components/preview/badge.test.tsx
PASS common/configHelper.test.ts

Test Suites: 12 passed, 12 total
Tests:       64 passed, 64 total
Snapshots:   15 passed, 15 total
Time:        1.029 s
Ran all test suites.
Checked 72 files in 16ms. No fixes applied.
Found 1 info.
