### PR TITLE
🤖 fix #855: 🐛 Stat toggles are inverted: stargazers=1 should hide the stat

### DIFF
--- a/.changeset/invert-stat-toggles.md
+++ b/.changeset/invert-stat-toggles.md
@@ -1,0 +1,5 @@
+---
+"socialify": patch
+---
+
+Invert stat toggle semantics so query value "0" enables and "1" disables optional stats

--- a/common/configHelper.test.ts
+++ b/common/configHelper.test.ts
@@ -16,24 +16,24 @@ const repository = {
 const query = (q: Partial<QueryType>) => q as QueryType
 
 describe('mergeConfig', () => {
-  test('stat query params use "1" to enable', () => {
+  test('stat query params use "0" to enable', () => {
     const config = mergeConfig(
       repository,
-      query({ stargazers: '1', forks: '1' })
+      query({ stargazers: '0', forks: '0' })
     )
     expect(config?.stargazers?.state).toBe(true)
     expect(config?.forks?.state).toBe(true)
   })
 
-  test('stat query params use "0" to disable', () => {
-    const config = mergeConfig(repository, query({ stargazers: '0' }))
+  test('stat query params use "1" to disable', () => {
+    const config = mergeConfig(repository, query({ stargazers: '1' }))
     expect(config?.stargazers?.state).toBe(false)
   })
 
   test('custom_description overrides the repository description', () => {
     const config = mergeConfig(
       repository,
-      query({ description: '1', custom_description: 'Hello' })
+      query({ description: '0', custom_description: 'Hello' })
     )
     expect(config?.description?.state).toBe(true)
     expect(config?.description?.value).toBe('Hello')

--- a/common/configHelper.ts
+++ b/common/configHelper.ts
@@ -111,7 +111,7 @@ const mergeConfig = (
     for (const key in query) {
       if (key in OptionalConfigsKeys) {
         Object.assign(config[key as Key] ?? {}, {
-          state: query[key as Key] === '1' || query[key as Key] === 'true',
+          state: query[key as Key] === '0' || query[key as Key] === 'false',
         })
         if (config[key as Key]?.editable) {
           const editableValue =

--- a/src/components/configuration/config.test.tsx
+++ b/src/components/configuration/config.test.tsx
@@ -88,7 +88,7 @@ describe('Config', () => {
     repoOwner: 'testowner',
     repoName: 'testrepo',
     currentPath: '/testowner/testrepo',
-    searchParamsString: 'theme=Light&language=1&owner=1&name=1&stargazers=1',
+    searchParamsString: 'theme=Light&language=0&owner=0&name=0&stargazers=0',
   }
 
   beforeEach(() => {

--- a/src/components/configuration/config.tsx
+++ b/src/components/configuration/config.tsx
@@ -51,10 +51,10 @@ export default function Config({
       }
 
       if (value && value.state === true && value.editable) {
-        urlParams[key] = '1'
+        urlParams[key] = '0'
         urlParams[`custom_${key}`] = value.value
       } else if (value && value.state === true) {
-        urlParams[key] = '1'
+        urlParams[key] = '0'
       } else if (value && value.required === true) {
         urlParams[key] = value.val
       } else {
@@ -98,7 +98,7 @@ export default function Config({
           const query = params.get(key)
           const currentConfig = newConfig[key as keyof typeof newConfig]
           const newChange = {
-            state: query === '1',
+            state: query === '0',
           }
           if (currentConfig?.editable) {
             const editableValue =

--- a/src/components/configuration/repositoryInput.test.tsx
+++ b/src/components/configuration/repositoryInput.test.tsx
@@ -24,7 +24,7 @@ describe('RepositoryInput', () => {
       owner: { login: 'testowner' },
       name: 'testrepo',
     },
-    currentSearchParams: 'theme=Light&language=1',
+    currentSearchParams: 'theme=Light&language=0',
   }
 
   beforeEach(() => {
@@ -140,7 +140,7 @@ describe('RepositoryInput', () => {
       fireEvent.click(submitButton)
 
       expect(mockPush).toHaveBeenCalledWith(
-        '/validowner/validrepo?theme=Light&language=1'
+        '/validowner/validrepo?theme=Light&language=0'
       )
       expect(toast.warning).not.toHaveBeenCalled()
     })
@@ -157,7 +157,7 @@ describe('RepositoryInput', () => {
       fireEvent.click(submitButton)
 
       expect(mockPush).toHaveBeenCalledWith(
-        '/facebook/react?theme=Light&language=1'
+        '/facebook/react?theme=Light&language=0'
       )
       expect(toast.warning).not.toHaveBeenCalled()
     })
@@ -246,14 +246,14 @@ describe('RepositoryInput', () => {
       fireEvent.submit(form)
 
       expect(mockPush).toHaveBeenCalledWith(
-        '/keyboardowner/keyboardrepo?theme=Light&language=1'
+        '/keyboardowner/keyboardrepo?theme=Light&language=0'
       )
     })
 
     it('preserves search parameters when switching repositories', () => {
       const propsWithParams = {
         ...defaultProps,
-        currentSearchParams: 'theme=Dark&font=Inter&language=1&owner=1',
+        currentSearchParams: 'theme=Dark&font=Inter&language=0&owner=0',
       }
 
       render(<RepositoryInput {...propsWithParams} />)
@@ -265,7 +265,7 @@ describe('RepositoryInput', () => {
       fireEvent.click(submitButton)
 
       expect(mockPush).toHaveBeenCalledWith(
-        '/newowner/newrepo?theme=Dark&font=Inter&language=1&owner=1'
+        '/newowner/newrepo?theme=Dark&font=Inter&language=0&owner=0'
       )
     })
 
@@ -300,7 +300,7 @@ describe('RepositoryInput', () => {
       fireEvent.click(submitButton)
 
       expect(mockPush).toHaveBeenCalledWith(
-        '/owner/repo-with-dashes_and_underscores.dots?theme=Light&language=1'
+        '/owner/repo-with-dashes_and_underscores.dots?theme=Light&language=0'
       )
     })
 
@@ -314,7 +314,7 @@ describe('RepositoryInput', () => {
       fireEvent.click(submitButton)
 
       expect(mockPush).toHaveBeenCalledWith(
-        '/owner/repo?theme=Light&language=1'
+        '/owner/repo?theme=Light&language=0'
       )
     })
 
@@ -330,7 +330,7 @@ describe('RepositoryInput', () => {
       fireEvent.click(submitButton)
 
       expect(mockPush).toHaveBeenCalledWith(
-        '/owner/repo?theme=Light&language=1'
+        '/owner/repo?theme=Light&language=0'
       )
     })
   })

--- a/src/components/repo/repo.tsx
+++ b/src/components/repo/repo.tsx
@@ -20,7 +20,7 @@ export default function Repo(): JSX.Element {
       ) ?? {}
     if (owner && name) {
       clientRouter.push(
-        `/${owner}/${name}?language=1&owner=1&name=1&stargazers=1&theme=Light`
+        `/${owner}/${name}?language=0&owner=0&name=0&stargazers=0&theme=Light`
       )
     } else {
       toast.warning('Please enter a valid GitHub repository.')


### PR DESCRIPTION
Closes #855



biome.json:30:13 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.
  
     28 │   },
     29 │   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   > 30 │   "linter": {
        │             ^
   > 31 │     "enabled": true,
         ...
  > 119 │     }
  > 120 │   },
        │   ^
    121 │   "javascript": {
    122 │     "formatter": {
  
  i Migrate the configuration with the proper command
  
  $ biome migrate
  

PASS src/components/configuration/config.test.tsx
PASS src/components/configuration/repositoryInput.test.tsx
PASS src/components/header/header.test.tsx
PASS src/components/preview/cardThemeWrapper.test.tsx
PASS src/components/configuration/inputWrapper.test.tsx
PASS src/components/configuration/logoInput.test.tsx
PASS src/components/repo/repo.test.tsx
PASS src/components/footer/footer.test.tsx
PASS src/components/error/error.test.tsx
PASS src/components/preview/badge.test.tsx
PASS common/configHelper.test.ts

Test Suites: 11 passed, 11 total
Tests:       62 passed, 62 total
Snapshots:   15 passed, 15 total
Time:        0.891 s, estimated 1 s
Ran all test suites.
Checked 71 files in 34ms. No fixes applied.
Found 1 info.
