### PR TITLE
🤖 fix #864: Add YYY Hero Pattern to the backgrounds dropdown

### DIFF
--- a/.changeset/yyy-hero-pattern.md
+++ b/.changeset/yyy-hero-pattern.md
@@ -1,0 +1,5 @@
+---
+"socialify": minor
+---
+
+Added YYY hero pattern to the backgrounds dropdown

--- a/common/helpers.test.ts
+++ b/common/helpers.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment node
+ */
+
+import { getHeroPattern } from '@/common/helpers'
+import { Pattern, Theme } from '@/common/types/configType'
+
+describe('getHeroPattern', () => {
+  describe('yyy pattern', () => {
+    for (const theme of [Theme.light, Theme.dark]) {
+      test(`returns backgroundImage and backgroundSize for ${theme}`, () => {
+        const result = getHeroPattern(Pattern.yyy, theme)
+        expect(result.backgroundImage).toBeTruthy()
+        expect(result.backgroundSize).toBe('60px 96px')
+        expect(result.backgroundRepeat).toBe('repeat')
+      })
+    }
+  })
+})

--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -8,6 +8,7 @@ import {
   overlappingHexagons,
   plus,
   signal,
+  yyy,
 } from 'hero-patterns'
 import type { CSSProperties } from 'react'
 
@@ -25,6 +26,7 @@ const getHeroPattern = (pattern: Pattern, theme: Theme): CSSProperties => {
     [Pattern.brickWall]: brickWall,
     [Pattern.floatingCogs]: floatingCogs,
     [Pattern.diagonalStripes]: diagonalStripes,
+    [Pattern.yyy]: yyy,
     [Pattern.solid]: null,
     [Pattern.transparent]: null,
   }

--- a/common/types/configType.ts
+++ b/common/types/configType.ts
@@ -14,6 +14,7 @@ enum Pattern {
   brickWall = 'Brick Wall',
   floatingCogs = 'Floating Cogs',
   diagonalStripes = 'Diagonal Stripes',
+  yyy = 'Yyy',
   solid = 'Solid',
   transparent = 'Transparent',
 }

--- a/src/components/configuration/__snapshots__/config.test.tsx.snap
+++ b/src/components/configuration/__snapshots__/config.test.tsx.snap
@@ -233,6 +233,11 @@ exports[`Config Component Rendering renders with correct styling consistency (sn
         Diagonal Stripes
       </option>
       <option
+        value="Yyy"
+      >
+        Yyy
+      </option>
+      <option
         value="Solid"
       >
         Solid
@@ -764,6 +769,11 @@ exports[`Config Component Rendering renders with correct styling consistency (sn
           value="Diagonal Stripes"
         >
           Diagonal Stripes
+        </option>
+        <option
+          value="Yyy"
+        >
+          Yyy
         </option>
         <option
           value="Solid"
@@ -1298,6 +1308,11 @@ exports[`Config Component Rendering renders with correct styling consistency (sn
           value="Diagonal Stripes"
         >
           Diagonal Stripes
+        </option>
+        <option
+          value="Yyy"
+        >
+          Yyy
         </option>
         <option
           value="Solid"


### PR DESCRIPTION
Closes #864

Let me verify the `yyy` export exists and check the existing test/snapshot structure.Let me verify the `yyy` named export exists in the hero-patterns module.The `yyy` export exists and produces a 60×96 tile. Now let me make the changes.Now let me create the unit test file and the changeset.The changeset command failed due to network. Let me create the changeset file manually.Now let me regenerate the snapshot and run the tests.The pnpm wrapper is failing on network. Let me try running jest directly.The only failing suite is `font.test.ts`, which requires network access to unpkg.com (pre-existing, unrelated to my change). My new `helpers.test.ts` passed and the config snapshot was updated. Let me verify the snapshot contains the new option.The snapshot now includes the `Yyy` option between `Diagonal Stripes` and `Solid`. Let me run lint on the changed files.All changes are complete. Let me verify the final state of the changeset file.Done. Summary of changes for issue #864:

1. **`common/types/configType.ts`** — Added `yyy = 'Yyy'` to the `Pattern` enum, positioned between `diagonalStripes` and `solid` (keeps the first 5 enum values unchanged so the Playwright `slice(0, 5)` tests are unaffected, and keeps `Solid`/`Transparent` as terminal "no-pattern" options).

2. **`common/helpers.ts`** — Imported `yyy` from `hero-patterns` and added `[Pattern.yyy]: yyy` to `PATTERN_FUNCTIONS_MAPPING`. The existing fallback and width/height regex + quote-stripping logic handle the 60×96 tile generically, so `backgroundSize` resolves to `60px 96px`.

3. **`common/helpers.test.ts`** (new) — Unit test asserting `getHeroPattern(Pattern.yyy, theme)` returns `backgroundImage`/`backgroundSize`/`backgroundRepeat` for both light and dark themes.

4. **`src/components/configuration/__snapshots__/config.test.tsx.snap`** — Regenerated; the `Yyy` option now appears in the pattern select between `Diagonal Stripes` and `Solid`.

5. **`.changeset/yyy-hero-pattern.md`** (new) — `minor` changeset per CONTRIBUTING.md.

Verification: `helpers.test.ts` passes and the config snapshot updated. The only failing suite is the pre-existing `font.test.ts`, which requires network access to unpkg.com (unavailable in this sandbox) and is unrelated to this change. Biome lint passes on all touched files.


biome.json:30:13 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  i The use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.
  
     28 │   },
     29 │   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   > 30 │   "linter": {
        │             ^
   > 31 │     "enabled": true,
         ...
  > 119 │     }
  > 120 │   },
        │   ^
    121 │   "javascript": {
    122 │     "formatter": {
  
  i Migrate the configuration with the proper command
  
  $ biome migrate
  

PASS src/components/configuration/config.test.tsx
PASS src/components/configuration/repositoryInput.test.tsx
PASS src/components/header/header.test.tsx
PASS src/components/preview/cardThemeWrapper.test.tsx
PASS src/components/configuration/inputWrapper.test.tsx
PASS src/components/configuration/logoInput.test.tsx
PASS src/components/repo/repo.test.tsx
PASS src/components/preview/badge.test.tsx
PASS src/components/footer/footer.test.tsx
PASS src/components/error/error.test.tsx
PASS common/helpers.test.ts

Test Suites: 11 passed, 11 total
Tests:       61 passed, 61 total
Snapshots:   15 passed, 15 total
Time:        1.311 s
Ran all test suites.
Checked 71 files in 16ms. No fixes applied.
Found 1 info.
